### PR TITLE
Fix links, spelling errors in site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is my personal website repo. [http://gabriellewis.me](http://gabriellewis.m
 
 It is hosted on Github Pages.
 
-I'm current working at [Panda](http://panda.af)
+I'm currently working at [Panda](http://panda.af)
 
 Check out one of my portfolio projects (built with React, Redux, and Ruby on Rails), [Thinkpiece](http://thinkpiece.space)
 

--- a/index.html
+++ b/index.html
@@ -56,14 +56,14 @@
 						<h2>Recent Work</h2>
 						<div class="row">
 							<article class="6u 12u$(xsmall) work-item">
-								<a class="image fit thumb" href="https://github.com/Gabriel-Lewis/Air/releases/tag/V1.0.1" target="blank"><img src="images/thumbs/air.png" alt="Air Mac App" /></a>
+                                                                <a class="image fit thumb" href="https://github.com/Gabriel-Lewis/Air/releases/tag/V1.0.1" target="_blank"><img src="images/thumbs/air.png" alt="Air Mac App" /></a>
 								<h3>Air macOS App</h3>
 								<p>Air is the easiest way to keep an eye on the Air Quality Index in your zip code from your Mac. US only for now.</p>
 								<br>
 								<a href="https://github.com/Gabriel-Lewis/Air/releases/tag/V1.0.1" target="_blank" class="button small icon fa-github">Github</a>
 							</article>
 							<article class="6u 12u$(xsmall) work-item">
-								<a class="image fit thumb" href="https://testflight.apple.com/join/HefmaD3X" target="blank"><img src="images/thumbs/grow.png" alt="grow" /></a>
+                                                                <a class="image fit thumb" href="https://testflight.apple.com/join/HefmaD3X" target="_blank"><img src="images/thumbs/grow.png" alt="grow" /></a>
 								<h3>Grow iOS App</h3>
 								<p>Track the health of your house plants with water reminders.</p>
 								<br>
@@ -72,14 +72,14 @@
 						</div>
 							<div class="row">
 							<article class="6u 12u$(xsmall) work-item">
-								<a href="images/fulls/.png" class="image fit thumb"><img src="images/thumbs/Panda-App1.png" alt="Panda App" /></a>
+                                                                <a href="images/thumbs/Panda-App1.png" class="image fit thumb"><img src="images/thumbs/Panda-App1.png" alt="Panda App" /></a>
 								<h3>Panda iOS App</h3>
 								<p>AR camera triggered by your voice.</p>
 								<br>
-								<a href="https://itunes.apple.com/us/app/panda/id1250583288?ls=1&mt=8s" target="_blank" class="button small icon fa-apple">App Store</a>
+                                                                <a href="https://itunes.apple.com/us/app/panda/id1250583288?ls=1&mt=8" target="_blank" class="button small icon fa-apple">App Store</a>
 							</article>
 							<article class="6u 12u$(xsmall) work-item">
-								<a href="images/fulls/hodlgang.png" class="image fit thumb"><img src="images/thumbs/hodlgang.jpg" alt="hodlgang" /></a>
+                                                                <a href="images/thumbs/hodlgang.jpg" class="image fit thumb"><img src="images/thumbs/hodlgang.jpg" alt="hodlgang" /></a>
 								<h3>HODLGANG</h3>
 								<p>A Chrome Extension that helps you hodl by blocking crypto websites.</p>
 								<br>
@@ -129,7 +129,7 @@
 									<h3 class="work-place">Litterati</h3>
 									<strong>Software Engineer</strong>
 								</div>
-								<p>Litterati's goal is to clean up the world's litter problem one photo at a time. With over 300,000 pieces of litter cleaned up, Litterati is cleaning the world one piece at a time. The Litterati iOS app allows users to snap pictures of litter they've picked up and caterogize and log it's location.</p>
+                                                                <p>Litterati's goal is to clean up the world's litter problem one photo at a time. With over 300,000 pieces of litter cleaned up, Litterati is cleaning the world one piece at a time. The Litterati iOS app allows users to snap pictures of litter they've picked up and categorize and log its location.</p>
 							</article>
 							<article class="6u$ 12u$(xsmall) work-item">
 								<a href="http://painless1099.com" target="_blank" class="image fit thumb"><img src="images/thumbs/painless.png" alt="Painless 1099" /></a>


### PR DESCRIPTION
## Summary
- fix broken links for Panda and Hodlgang projects
- open project links in a new tab
- correct spelling mistakes and grammar

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844849fab6c8330998921df82ae806f